### PR TITLE
libstdc++: Add nodiscard attribute to mutex try_lock functions

### DIFF
--- a/m64-1X00/include/C⁺⁺/13.0.0/bits/std_mutex.h
+++ b/m64-1X00/include/C⁺⁺/13.0.0/bits/std_mutex.h
@@ -117,6 +117,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	__throw_system_error(__e);
     }
 
+    _GLIBCXX_NODISCARD
     bool
     try_lock() noexcept
     {

--- a/m64-1X00/include/C⁺⁺/13.0.0/mutex
+++ b/m64-1X00/include/C⁺⁺/13.0.0/mutex
@@ -501,6 +501,7 @@ typedef recursive_timed_mutex timed_mutex;
 	__throw_system_error(__e);
     }
 
+    _GLIBCXX_NODISCARD
     bool
     try_lock() noexcept
     {
@@ -630,6 +631,7 @@ typedef recursive_timed_mutex timed_mutex;
 	__throw_system_error(__e);
     }
 
+    _GLIBCXX_NODISCARD
     bool
     try_lock() noexcept
     {
@@ -638,11 +640,13 @@ typedef recursive_timed_mutex timed_mutex;
     }
 
     template <class _Rep, class _Period>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_for(const chrono::duration<_Rep, _Period>& __rtime)
       { return _M_try_lock_for(__rtime); }
 
     template <class _Clock, class _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<_Clock, _Duration>& __atime)
       { return _M_try_lock_until(__atime); }
@@ -705,6 +709,7 @@ typedef recursive_timed_mutex timed_mutex;
 	__throw_system_error(__e);
     }
 
+    _GLIBCXX_NODISCARD
     bool
     try_lock() noexcept
     {
@@ -713,11 +718,13 @@ typedef recursive_timed_mutex timed_mutex;
     }
 
     template <class _Rep, class _Period>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_for(const chrono::duration<_Rep, _Period>& __rtime)
       { return _M_try_lock_for(__rtime); }
 
     template <class _Clock, class _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<_Clock, _Duration>& __atime)
       { return _M_try_lock_until(__atime); }
@@ -772,6 +779,7 @@ typedef recursive_timed_mutex timed_mutex;
       _M_locked = true;
     }
 
+    _GLIBCXX_NODISCARD
     bool
     try_lock()
     {
@@ -783,6 +791,7 @@ typedef recursive_timed_mutex timed_mutex;
     }
 
     template<typename _Rep, typename _Period>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_for(const chrono::duration<_Rep, _Period>& __rtime)
       {
@@ -794,6 +803,7 @@ typedef recursive_timed_mutex timed_mutex;
       }
 
     template<typename _Clock, typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<_Clock, _Duration>& __atime)
       {
@@ -855,6 +865,7 @@ typedef recursive_timed_mutex timed_mutex;
       ++_M_count;
     }
 
+    _GLIBCXX_NODISCARD
     bool
     try_lock()
     {
@@ -871,6 +882,7 @@ typedef recursive_timed_mutex timed_mutex;
     }
 
     template<typename _Rep, typename _Period>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_for(const chrono::duration<_Rep, _Period>& __rtime)
       {
@@ -887,6 +899,7 @@ typedef recursive_timed_mutex timed_mutex;
       }
 
     template<typename _Clock, typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<_Clock, _Duration>& __atime)
       {
@@ -993,6 +1006,7 @@ typedef recursive_timed_mutex timed_mutex;
    *  Sequentially calls try_lock() on each argument.
    */
   template<typename _L1, typename _L2, typename... _L3>
+    _GLIBCXX_NODISCARD
     inline int
     try_lock(_L1& __l1, _L2& __l2, _L3&... __l3)
     {

--- a/m64-1X00/include/C⁺⁺/13.0.0/shared_mutex
+++ b/m64-1X00/include/C⁺⁺/13.0.0/shared_mutex
@@ -757,13 +757,13 @@ public:
     // Exclusive ownership
 
     void lock() { _M_impl.lock(); }
-    bool try_lock() { return _M_impl.try_lock(); }
+    [[nodiscard]] bool try_lock() { return _M_impl.try_lock(); }
     void unlock() { _M_impl.unlock(); }
 
     // Shared ownership
 
     void lock_shared() { _M_impl.lock_shared(); }
-    bool try_lock_shared() { return _M_impl.try_lock_shared(); }
+    [[nodiscard]] bool try_lock_shared() { return _M_impl.try_lock_shared(); }
     void unlock_shared() { _M_impl.unlock_shared(); }
 
 #if _GLIBCXX_USE_PTHREAD_RWLOCK_T
@@ -810,10 +810,11 @@ public:
     // Exclusive ownership
 
     void lock() { _Base::lock(); }
-    bool try_lock() { return _Base::try_lock(); }
+    _GLIBCXX_NODISCARD bool try_lock() { return _Base::try_lock(); }
     void unlock() { _Base::unlock(); }
 
     template<typename _Rep, typename _Period>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_for(const chrono::duration<_Rep, _Period>& __rtime)
       {
@@ -826,10 +827,12 @@ public:
     // Shared ownership
 
     void lock_shared() { _Base::lock_shared(); }
+    _GLIBCXX_NODISCARD
     bool try_lock_shared() { return _Base::try_lock_shared(); }
     void unlock_shared() { _Base::unlock_shared(); }
 
     template<typename _Rep, typename _Period>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_shared_for(const chrono::duration<_Rep, _Period>& __rtime)
       {
@@ -844,6 +847,7 @@ public:
     // Exclusive ownership
 
     template<typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<chrono::system_clock,
 		     _Duration>& __atime)
@@ -869,6 +873,7 @@ public:
 
 #ifdef _GLIBCXX_USE_PTHREAD_RWLOCK_CLOCKLOCK
     template<typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<chrono::steady_clock,
 		   _Duration>& __atime)
@@ -895,6 +900,7 @@ public:
 #endif
 
     template<typename _Clock, typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<_Clock, _Duration>& __atime)
       {
@@ -917,6 +923,7 @@ public:
     // Shared ownership
 
     template<typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_shared_until(const chrono::time_point<chrono::system_clock,
 			    _Duration>& __atime)
@@ -956,6 +963,7 @@ public:
 
 #ifdef _GLIBCXX_USE_PTHREAD_RWLOCK_CLOCKLOCK
     template<typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_shared_until(const chrono::time_point<chrono::steady_clock,
 			    _Duration>& __atime)
@@ -982,6 +990,7 @@ public:
 #endif
 
     template<typename _Clock, typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_shared_until(const chrono::time_point<_Clock,
 						     _Duration>& __atime)
@@ -1007,6 +1016,7 @@ public:
     // Exclusive ownership
 
     template<typename _Clock, typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_until(const chrono::time_point<_Clock, _Duration>& __abs_time)
       {
@@ -1031,6 +1041,7 @@ public:
     // Shared ownership
 
     template <typename _Clock, typename _Duration>
+      _GLIBCXX_NODISCARD
       bool
       try_lock_shared_until(const chrono::time_point<_Clock,
 						     _Duration>& __abs_time)
@@ -1144,6 +1155,7 @@ public:
 	_M_owns = true;
       }
 
+      _GLIBCXX_NODISCARD
       bool
       try_lock()
       {
@@ -1152,6 +1164,7 @@ public:
       }
 
       template<typename _Rep, typename _Period>
+	_GLIBCXX_NODISCARD
 	bool
 	try_lock_for(const chrono::duration<_Rep, _Period>& __rel_time)
 	{
@@ -1160,6 +1173,7 @@ public:
 	}
 
       template<typename _Clock, typename _Duration>
+	_GLIBCXX_NODISCARD
 	bool
 	try_lock_until(const chrono::time_point<_Clock, _Duration>& __abs_time)
 	{
@@ -1194,10 +1208,12 @@ public:
 
       // Getters
 
+      _GLIBCXX_NODISCARD
       bool owns_lock() const noexcept { return _M_owns; }
 
       explicit operator bool() const noexcept { return _M_owns; }
 
+      _GLIBCXX_NODISCARD
       mutex_type* mutex() const noexcept { return _M_pm; }
 
     private:


### PR DESCRIPTION
libstdc++-v3/ChangeLog:

	* include/bits/std_mutex.h (mutex): Add nodiscard attribute to
	try_lock member function.
	* include/bits/unique_lock.h (unique_lock): Likewise for
	try_lock, try_lock_until, try_lock_for member functions, and
	owns_lock and mutex member functions.
	* include/std/mutex (recursive_mutex): Likewise for try_lock
	member function.
	(timed_mutex, recursive_timed_mutex, try_lock): Likewise for
	try_lock, try_lock_until, try_lock_for member functions.
	(try_lock): Likewise for non-member function.
	* include/std/shared_mutex (shared_mutex): Likewise for try_lock
	and try_lock_shared member functions.
	(shared_timed_mutex): Likewise for try_lock, try_lock_for,
	try_lock_shared, try_lock_shared_for, try_lock_until, and
	try_lock_shared_until member functions.
	(shared_lock): Likewise for try_lock, try_lock, try_lock_for,
	try_lock_until, owns_lock, and mutex member functions.
	* testsuite/30_threads/recursive_timed_mutex/try_lock_until/clock_neg.cc:
	Cast discarded value expression to void.
	* testsuite/30_threads/shared_lock/locking/3.cc: Likewise.
	* testsuite/30_threads/shared_lock/locking/4.cc: Likewise.
	* testsuite/30_threads/shared_lock/locking/clock_neg.cc:
	Likewise.
	* testsuite/30_threads/shared_timed_mutex/try_lock_until/clock_neg.cc:
	Likewise.
	* testsuite/30_threads/timed_mutex/try_lock_until/clock_neg.cc:
	Likewise.
	* testsuite/30_threads/try_lock/4.cc: Likewise.
	* testsuite/30_threads/unique_lock/cons/60497.cc: Likewise.
	* testsuite/30_threads/unique_lock/locking/3.cc: Likewise.
	* testsuite/30_threads/unique_lock/locking/clock_neg.cc:
	Likewise.